### PR TITLE
fix: fixes docker_info for windows (#26)

### DIFF
--- a/src-tauri/src/entities/docker_info.rs
+++ b/src-tauri/src/entities/docker_info.rs
@@ -92,7 +92,10 @@ pub struct DockerInfo {
     pub version_os: Option<String>,
     pub version_arch: Option<String>,
     pub version_kernel_version: Option<String>,
+    #[cfg(not(target_os = "windows"))]
     pub version_experimental: Option<String>,
+    #[cfg(target_os = "windows")]
+    pub version_experimental: Option<bool>,
     pub build_time: Option<String>,
 
     pub status: DockerStatus,


### PR DESCRIPTION
### Which issue does this PR close?

Build failure on windows, works on wsl ubuntu

- Closes #26

## Rationale for this change

Docker’s /version endpoint is unfortunately inconsistent across platforms.  This fixes so that it will properly work on windows, linux and presumably mac os.

