### PR TITLE
[fix]: set targets for build macos

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Install frontend dependencies
         run: npm ci


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build configuration to include both Apple Silicon and Intel targets, ensuring binaries are built for aarch64 and x86_64.
  * Improves compatibility of macOS artifacts across newer and older Macs without altering app behavior or features.
  * No changes to user workflows; installation and usage remain the same, with broader support across macOS hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->