### PR TITLE
fix: stop the Colima VM instead of reporting a stop that never happened

### DIFF
--- a/src-tauri/src/services/engine/macos.rs
+++ b/src-tauri/src/services/engine/macos.rs
@@ -1,13 +1,16 @@
 use crate::entities::{
     ColimaConfig, ColimaEngineStopProgress, InstallationMethod, InstallationProgress,
 };
+use crate::services::engine::should_stop_vm;
 use crate::services::shell::{
     check_colima_status, get_docker_context_endpoints, install_packages_via_homebrew,
     start_colima_with_config, stop_colima, validate_colima_startup,
 };
 use bollard::Docker;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
+use tokio::time::Instant;
 use tracing::{debug, instrument, warn};
 
 #[instrument(skip_all, err)]
@@ -227,6 +230,34 @@ pub async fn start_colima_vm(app_handle: &AppHandle, config: ColimaConfig) -> Re
     result
 }
 
+/// Poll `colima status` until the VM reports as stopped.
+///
+/// `colima stop` returns before the VM has fully torn down, so the shutdown has
+/// to be observed rather than assumed after a fixed delay.
+#[instrument(skip_all, err)]
+async fn wait_for_colima_stopped(app_handle: &AppHandle) -> Result<(), String> {
+    const POLL_INTERVAL: Duration = Duration::from_millis(500);
+    const TIMEOUT: Duration = Duration::from_secs(60);
+
+    let deadline = Instant::now() + TIMEOUT;
+
+    loop {
+        if let Ok(false) = check_colima_status(app_handle).await {
+            debug!("Colima VM reported as stopped");
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "Colima VM did not report as stopped within {} seconds",
+                TIMEOUT.as_secs()
+            ));
+        }
+
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
 #[instrument(skip_all, err)]
 pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
     debug!("Stopping Colima VM");
@@ -263,13 +294,13 @@ pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
         let _ = tx_clone.send(progress.clone()).await;
 
         let status_result = check_colima_status(&app_handle_clone).await;
-        if let Ok(true) = status_result {
-            progress.step = "Colima VM is running".to_string();
-            progress.message = "Colima VM is running".to_string();
-            progress.percentage = 30;
+        if !should_stop_vm(&status_result) {
+            progress.step = "Colima VM is already stopped".to_string();
+            progress.message = "Colima VM was not running, nothing to stop".to_string();
+            progress.percentage = 100;
             progress
                 .logs
-                .push("[INFO] Colima VM is running".to_string());
+                .push("[INFO] Colima VM is already stopped".to_string());
             let _ = tx_clone.send(progress.clone()).await;
             return Ok(());
         }
@@ -290,8 +321,24 @@ pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
             let _ = tx_clone.send(progress.clone()).await;
             return Err(e.clone());
         }
-        // Wait a bit for the VM to fully stop
-        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+
+        // Step 3: Confirm the VM actually went down
+        progress.step = "Confirming VM shutdown...".to_string();
+        progress.message = "Waiting for the Colima VM to report as stopped".to_string();
+        progress.percentage = 70;
+        progress
+            .logs
+            .push("[INFO] Waiting for Colima VM to report as stopped".to_string());
+        let _ = tx_clone.send(progress.clone()).await;
+
+        if let Err(e) = wait_for_colima_stopped(&app_handle_clone).await {
+            progress.step = "VM stop failed".to_string();
+            progress.message = e.clone();
+            progress.percentage = 100;
+            progress.logs.push(format!("[ERROR] {}", e));
+            let _ = tx_clone.send(progress.clone()).await;
+            return Err(e);
+        }
 
         progress.step = "VM stop complete".to_string();
         progress.message = "Colima VM is stopped successfully".to_string();

--- a/src-tauri/src/services/engine/macos.rs
+++ b/src-tauri/src/services/engine/macos.rs
@@ -10,7 +10,6 @@ use bollard::Docker;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
-use tokio::time::Instant;
 use tracing::{debug, instrument, warn};
 
 #[instrument(skip_all, err)]
@@ -233,29 +232,51 @@ pub async fn start_colima_vm(app_handle: &AppHandle, config: ColimaConfig) -> Re
 /// Poll `colima status` until the VM reports as stopped.
 ///
 /// `colima stop` returns before the VM has fully torn down, so the shutdown has
-/// to be observed rather than assumed after a fixed delay.
+/// to be observed rather than assumed after a fixed delay. The whole wait is
+/// bounded, so a `colima status` invocation that never returns cannot wedge the
+/// stop flow.
 #[instrument(skip_all, err)]
 async fn wait_for_colima_stopped(app_handle: &AppHandle) -> Result<(), String> {
     const POLL_INTERVAL: Duration = Duration::from_millis(500);
     const TIMEOUT: Duration = Duration::from_secs(60);
 
-    let deadline = Instant::now() + TIMEOUT;
+    // A status check can fail transiently while the VM tears down, so keep
+    // polling on error and report the last failure only if the wait expires.
+    let mut last_error: Option<String> = None;
 
-    loop {
-        if let Ok(false) = check_colima_status(app_handle).await {
-            debug!("Colima VM reported as stopped");
-            return Ok(());
+    let poll = async {
+        loop {
+            match check_colima_status(app_handle).await {
+                Ok(false) => return,
+                Ok(true) => last_error = None,
+                Err(e) => {
+                    warn!("Failed to check Colima status while stopping: {}", e);
+                    last_error = Some(e);
+                }
+            }
+
+            tokio::time::sleep(POLL_INTERVAL).await;
         }
+    };
 
-        if Instant::now() >= deadline {
-            return Err(format!(
-                "Colima VM did not report as stopped within {} seconds",
-                TIMEOUT.as_secs()
-            ));
-        }
+    let stopped = tokio::time::timeout(TIMEOUT, poll).await.is_ok();
 
-        tokio::time::sleep(POLL_INTERVAL).await;
+    if stopped {
+        debug!("Colima VM reported as stopped");
+        return Ok(());
     }
+
+    Err(match last_error {
+        Some(e) => format!(
+            "Colima VM did not report as stopped within {} seconds; the last status check failed: {}",
+            TIMEOUT.as_secs(),
+            e
+        ),
+        None => format!(
+            "Colima VM did not report as stopped within {} seconds",
+            TIMEOUT.as_secs()
+        ),
+    })
 }
 
 #[instrument(skip_all, err)]
@@ -302,7 +323,7 @@ pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
                 .logs
                 .push("[INFO] Colima VM is already stopped".to_string());
             let _ = tx_clone.send(progress.clone()).await;
-            return Ok(());
+            return Ok(progress);
         }
 
         // Step 2: Stop Colima VM
@@ -348,7 +369,7 @@ pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
             .push("[INFO] Colima VM stopped successfully".to_string());
         let _ = tx_clone.send(progress.clone()).await;
 
-        Ok(())
+        Ok(progress)
     });
 
     // Handle progress updates and send them to the frontend
@@ -364,17 +385,19 @@ pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
         .await
         .map_err(|e| format!("VM stop task failed: {}", e))?;
 
-    // Send completion event
+    // Send completion event. The terminal progress rides along with it: the
+    // relay task above may not have drained the channel yet, so the frontend
+    // cannot rely on the last `vm-stop-progress` arriving first.
     match &result {
-        Ok(_) => {
-            let _ = app_handle_for_events.emit("vm-stop-complete", ());
+        Ok(final_progress) => {
+            let _ = app_handle_for_events.emit("vm-stop-complete", final_progress);
         }
         Err(e) => {
             let _ = app_handle_for_events.emit("vm-stop-error", e);
         }
     }
 
-    result
+    result.map(|_| ())
 }
 
 #[instrument(skip_all, err)]

--- a/src-tauri/src/services/engine/mod.rs
+++ b/src-tauri/src/services/engine/mod.rs
@@ -87,3 +87,33 @@ pub async fn create_engine(app: &AppHandle) -> Result<Engine, String> {
         docker: None,
     })
 }
+
+/// Decide whether a stop request should actually issue `colima stop`.
+///
+/// Only a definitive "the VM is not running" answer justifies skipping the
+/// stop. A failed status check falls through to attempting the stop, so an
+/// unreadable status can never make the app report a stop it never performed.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub fn should_stop_vm(status: &Result<bool, String>) -> bool {
+    !matches!(status, Ok(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_stop_vm;
+
+    #[test]
+    fn stops_when_the_vm_is_running() {
+        assert!(should_stop_vm(&Ok(true)));
+    }
+
+    #[test]
+    fn skips_the_stop_when_the_vm_is_not_running() {
+        assert!(!should_stop_vm(&Ok(false)));
+    }
+
+    #[test]
+    fn attempts_the_stop_when_the_status_check_fails() {
+        assert!(should_stop_vm(&Err("colima not found".to_string())));
+    }
+}

--- a/src-tauri/src/services/shell/macos.rs
+++ b/src-tauri/src/services/shell/macos.rs
@@ -203,12 +203,22 @@ pub async fn check_colima_status(app: &AppHandle) -> Result<bool, String> {
         .await
         .map_err(|e| format!("Failed to check Colima status: {}", e))?;
 
+    // `colima status` reports through its logger, which writes to stderr and
+    // leaves stdout empty, so the report has to be read from both streams.
+    // The exit code is the authoritative signal: 0 when the VM is running,
+    // non-zero (with "colima is not running") when it is not.
     if !output.status.success() {
         return Ok(false);
     }
 
-    let status_text = String::from_utf8_lossy(&output.stdout);
-    Ok(status_text.contains("Running"))
+    let status_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+    .to_lowercase();
+
+    Ok(!status_text.contains("is not running"))
 }
 
 #[instrument(skip_all, err)]

--- a/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
+++ b/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
@@ -227,18 +227,16 @@ export function useEngineSettingsState(): [
         });
         unlistenPromises.push(unlistenStopProgress);
 
-        const unlistenStopComplete = listen('vm-stop-complete', async () => {
+        const unlistenStopComplete = listen('vm-stop-complete', async event => {
           setStopStep('complete');
-          // The backend reports what it actually did (stopped the VM, or found
-          // it already stopped), so keep its final message instead of claiming
-          // a stop that may not have happened.
-          setStopProgress(prev => ({
-            step: prev.step || 'Engine Stopped',
-            message:
-              prev.message || 'Colima engine has been stopped successfully',
-            percentage: 100,
-            logs: prev.logs,
-          }));
+          // The event carries the terminal progress, so the final state does
+          // not depend on the last 'vm-stop-progress' arriving first. The
+          // backend reports what it actually did (stopped the VM, or found it
+          // already stopped), so keep its message instead of claiming a stop
+          // that may not have happened.
+          const finalProgress =
+            event.payload as ColimaEngineStopProgressType | null;
+          setStopProgress(prev => finalProgress ?? { ...prev, percentage: 100 });
           // Refresh Docker info after stopping
           setTimeout(() => {
             fetchDockerInfo().catch(() => {});

--- a/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
+++ b/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
@@ -229,11 +229,15 @@ export function useEngineSettingsState(): [
 
         const unlistenStopComplete = listen('vm-stop-complete', async () => {
           setStopStep('complete');
+          // The backend reports what it actually did (stopped the VM, or found
+          // it already stopped), so keep its final message instead of claiming
+          // a stop that may not have happened.
           setStopProgress(prev => ({
-            step: 'Engine Stopped',
-            message: 'Colima engine has been stopped successfully',
+            step: prev.step || 'Engine Stopped',
+            message:
+              prev.message || 'Colima engine has been stopped successfully',
             percentage: 100,
-            logs: [...prev.logs, '[INFO] Engine stopped successfully'],
+            logs: prev.logs,
           }));
           // Refresh Docker info after stopping
           setTimeout(() => {


### PR DESCRIPTION
Closes #168

## Problem

Two defects compound in the "Stop Engine" flow, and they currently cancel each other out.

**`check_colima_status` never reports a running VM.** It read `colima status` from stdout and matched the literal `"Running"`. colima reports through its logger, which writes to **stderr** and leaves stdout empty, and it says `colima is running` in lowercase. Verified on macOS against a live VM in both states:

| VM state | exit | stdout | old check | new check |
|---|---|---|---|---|
| running | 0 | *(empty)* | `false` :x: | `true` :white_check_mark: |
| stopped | 1 | *(empty)* | `false` | `false` :white_check_mark: |

**`stop_colima_vm` returned early on the wrong branch,** skipping `colima stop` whenever the VM was reported as running - a copy-paste of the early return in `start_colima_vm`, where returning early on `Ok(true)` is correct.

The broken status check masked the inverted branch: because the check was stuck at `false`, the early return was never taken and the stop did run. **Fixing only the inverted branch, as the original issue write-up suggested, would have broken stopping entirely** - `Ok(false)` would then trigger the "already stopped" early return on every attempt. Both had to be fixed together.

## Changes

- **`shell/macos.rs`** - `check_colima_status` reads stdout and stderr and treats the exit code as the authoritative signal.
- **`engine/macos.rs`** - the stop branch is inverted to skip only on a definitive "not running"; teardown is now confirmed by polling until the VM reports as stopped (500ms interval, 60s timeout) rather than assumed after a hardcoded `sleep(5s)`; the 40% -> 100% progress gap is filled with a real step.
- **`engine/mod.rs`** - the branch decision is extracted into `should_stop_vm` with unit tests. It lives in the platform-neutral module deliberately: CI runs `cargo test` on `ubuntu-22.04`, so a test gated behind `#[cfg(target_os = "macos")]` would never run there.
- **`use-engine-settings-state.ts`** - the hook hardcoded `'Colima engine has been stopped successfully'` on `vm-stop-complete`, overwriting the backend's report; it now keeps the message the backend actually sent, so the already-stopped path says so.

A failed status check falls through to attempting the stop, so an unreadable status can never make the app claim a stop it did not perform.

## Side effect

`start_colima_vm`'s "Colima is already running" early return never fired before, because the status check could not return `true`. It now works, so starting an already-running VM no longer shells out to `colima start` again.

## Verification

- `colima status` contract verified against a live VM in both running and stopped states (table above).
- `cargo test` - 6 passed (3 new).
- `pre-commit run` on all changed files - eslint, TypeScript, lint, cargo fmt, cargo check, cargo test all pass.

Full GUI click-through of Settings -> Engine -> Stop Engine was not run; the app is a native Tauri window and I have no native GUI automation available in this environment. The shell-level contract that the bug hinged on is verified directly against a real VM instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved virtual machine shutdown handling by confirming the VM has fully stopped before completing the operation.
  - Fixed status detection when shutdown information is reported through error output.
  - Improved handling of VM status-check failures so shutdown attempts proceed appropriately.
  - Preserved backend-reported shutdown progress details in Settings, including the final completion state.
  - Improved timeout reporting while allowing shutdown checks to continue through temporary status errors.
  - Prevented inaccurate or duplicate success messages from appearing in engine logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->