### PR TITLE
fix: stop volume prune from deleting named volumes Docker protects

### DIFF
--- a/src-tauri/src/entities/volumes.rs
+++ b/src-tauri/src/entities/volumes.rs
@@ -1,4 +1,4 @@
-use bollard::models::{VolumeScopeEnum, VolumeUsageData};
+use bollard::models::{VolumePruneResponse, VolumeScopeEnum, VolumeUsageData};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -65,5 +65,57 @@ impl From<bollard::models::Volume> for Volume {
             options: volume.options,
             usage_data: volume.usage_data.map(UsageData::from),
         }
+    }
+}
+
+/// Outcome of a volume prune, taken verbatim from the daemon's prune response.
+///
+/// Never derive these numbers by diffing the volume list before and after the
+/// prune: that races with anything else touching the daemon and cannot tell a
+/// pruned volume from one created or removed concurrently.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VolumePruneResult {
+    pub volumes_deleted: Vec<String>,
+    pub space_reclaimed: i64,
+}
+
+impl From<VolumePruneResponse> for VolumePruneResult {
+    fn from(response: VolumePruneResponse) -> Self {
+        VolumePruneResult {
+            volumes_deleted: response.volumes_deleted.unwrap_or_default(),
+            space_reclaimed: response.space_reclaimed.unwrap_or_default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prune_result_takes_the_daemon_response_verbatim() {
+        let response = VolumePruneResponse {
+            volumes_deleted: Some(vec!["anon-a".to_string(), "anon-b".to_string()]),
+            space_reclaimed: Some(2048),
+        };
+
+        let result = VolumePruneResult::from(response);
+
+        assert_eq!(result.volumes_deleted, vec!["anon-a", "anon-b"]);
+        assert_eq!(result.space_reclaimed, 2048);
+    }
+
+    #[test]
+    fn prune_result_reports_nothing_deleted_when_the_daemon_omits_the_fields() {
+        // The daemon omits both fields when it removed nothing. That must read
+        // as "zero volumes deleted", never as missing data to be filled in by
+        // some client-side estimate.
+        let result = VolumePruneResult::from(VolumePruneResponse {
+            volumes_deleted: None,
+            space_reclaimed: None,
+        });
+
+        assert!(result.volumes_deleted.is_empty());
+        assert_eq!(result.space_reclaimed, 0);
     }
 }

--- a/src-tauri/src/handlers/volumes.rs
+++ b/src-tauri/src/handlers/volumes.rs
@@ -1,4 +1,4 @@
-use crate::entities::Volume;
+use crate::entities::{Volume, VolumePruneResult};
 use crate::services::VolumesService;
 use crate::state::SharedEngineState;
 use tauri::State;
@@ -55,24 +55,13 @@ pub async fn inspect_volume(
 
 #[tauri::command]
 #[instrument(skip_all, err)]
-pub async fn prune_volumes(state: State<'_, SharedEngineState>) -> Result<String, String> {
+pub async fn prune_volumes(
+    state: State<'_, SharedEngineState>,
+) -> Result<VolumePruneResult, String> {
     debug!("Pruning unused volumes");
 
     let engine = state.get_engine().await?;
     let docker = engine.docker.as_ref().ok_or("Docker not found")?;
 
-    // Get initial count of volumes
-    let initial_volumes = VolumesService::get_volumes(docker).await?;
-    let initial_count = initial_volumes.len();
-
-    // Perform the pruning
-    VolumesService::prune_volumes(docker).await?;
-
-    // Get final count of volumes
-    let final_volumes = VolumesService::get_volumes(docker).await?;
-    let final_count = final_volumes.len();
-
-    let pruned_count = initial_count.saturating_sub(final_count);
-
-    Ok(format!("Pruned {} unused volumes", pruned_count))
+    VolumesService::prune_volumes(docker).await
 }

--- a/src-tauri/src/services/volumes.rs
+++ b/src-tauri/src/services/volumes.rs
@@ -1,10 +1,9 @@
-use tokio::time;
 use tracing::{debug, instrument};
 
 #[derive(Default, Debug)]
 pub struct VolumesService {}
 
-use crate::entities::Volume;
+use crate::entities::{Volume, VolumePruneResult};
 use bollard::container::ListContainersOptions;
 use bollard::volume::{ListVolumesOptions, PruneVolumesOptions, RemoveVolumeOptions};
 use bollard::Docker;
@@ -91,100 +90,35 @@ impl VolumesService {
         Ok(Volume::from(bollard_volume))
     }
 
+    /// Prune volumes using the daemon's own prune endpoint, and nothing else.
+    ///
+    /// Docker deliberately restricts `volume prune` to *anonymous* volumes: named
+    /// volumes are the ones users create to outlive container churn (database data
+    /// directories, caches, uploads), so removing them is never implied by "prune
+    /// unused". The daemon is also the only party that can see every reason a
+    /// volume is protected -- swarm cluster volumes, containers outside the
+    /// current context -- so its answer is authoritative and is not second-guessed
+    /// here. Named volumes are removed only through an explicit selection in the
+    /// UI, which routes to `remove_volume` / `bulk_remove_volumes`.
     #[instrument(skip_all, err)]
-    pub async fn prune_volumes(docker: &Docker) -> Result<(), String> {
-        debug!("Starting volume pruning process");
+    pub async fn prune_volumes(docker: &Docker) -> Result<VolumePruneResult, String> {
+        debug!("Pruning unused anonymous volumes");
 
-        // First, try the standard prune operation
         let options: PruneVolumesOptions<String> = PruneVolumesOptions::default();
 
-        let result = docker
+        let result: VolumePruneResult = docker
             .prune_volumes(Some(options))
             .await
-            .map_err(|e| format!("Failed to prune volumes: {}", e))?;
+            .map_err(|e| format!("Failed to prune volumes: {}", e))?
+            .into();
 
-        // Log the result for debugging
-        if let Some(volumes_deleted) = &result.volumes_deleted {
-            debug!(
-                "Standard prune removed {} volumes: {:?}",
-                volumes_deleted.len(),
-                volumes_deleted
-            );
-        }
-        if let Some(space_reclaimed) = result.space_reclaimed {
-            debug!("Reclaimed {} bytes", space_reclaimed);
-        }
-
-        // After standard prune, manually check for any remaining unused volumes
-        // and remove them to ensure complete cleanup
-        debug!("Checking for remaining unused volumes after standard prune");
-        let remaining_volumes = Self::get_volumes(docker).await?;
         debug!(
-            "Found {} remaining volumes after standard prune",
-            remaining_volumes.len()
+            "Prune removed {} volumes, reclaiming {} bytes: {:?}",
+            result.volumes_deleted.len(),
+            result.space_reclaimed,
+            result.volumes_deleted
         );
 
-        let unused_volumes: Vec<String> = remaining_volumes
-            .into_iter()
-            .filter(|volume| {
-                // A volume is unused if it has no reference count
-                let is_unused = volume
-                    .usage_data
-                    .as_ref()
-                    .map(|usage| usage.ref_count == 0)
-                    .unwrap_or(true);
-
-                if is_unused {
-                    debug!(
-                        "Volume {} appears to be unused (ref_count: {:?})",
-                        volume.name,
-                        volume.usage_data.as_ref().map(|u| u.ref_count)
-                    );
-                } else {
-                    debug!(
-                        "Volume {} is still in use (ref_count: {:?})",
-                        volume.name,
-                        volume.usage_data.as_ref().map(|u| u.ref_count)
-                    );
-                }
-
-                is_unused
-            })
-            .map(|volume| volume.name)
-            .collect();
-
-        if !unused_volumes.is_empty() {
-            debug!(
-                "Found {} additional unused volumes after standard prune: {:?}",
-                unused_volumes.len(),
-                unused_volumes
-            );
-
-            // Remove the remaining unused volumes with a small delay between operations
-            // to avoid overwhelming the Docker daemon
-            for (index, volume_name) in unused_volumes.iter().enumerate() {
-                if let Err(e) = Self::remove_volume(docker, volume_name).await {
-                    debug!("Failed to remove unused volume {}: {}", volume_name, e);
-                    // Continue with other volumes even if one fails
-                } else {
-                    debug!("Successfully removed unused volume: {}", volume_name);
-                }
-
-                // Add a small delay between operations (except for the last one)
-                if index < unused_volumes.len() - 1 {
-                    time::sleep(time::Duration::from_millis(100)).await;
-                }
-            }
-
-            debug!(
-                "Manually removed {} additional unused volumes",
-                unused_volumes.len()
-            );
-        } else {
-            debug!("No additional unused volumes found after standard prune");
-        }
-
-        debug!("Volume pruning process completed");
-        Ok(())
+        Ok(result)
     }
 }

--- a/src/components/volumes/index.ts
+++ b/src/components/volumes/index.ts
@@ -12,4 +12,4 @@ export { VolumeActions } from './volume-actions';
 export { VolumeActionService } from './volume-actions-service';
 
 // Types
-export { type Volume } from './volume-types';
+export { type Volume, type VolumePruneResult } from './volume-types';

--- a/src/components/volumes/volume-actions-service.ts
+++ b/src/components/volumes/volume-actions-service.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { toast } from 'sonner';
+import { VolumePruneResult } from './volume-types';
+import { formatBytes } from '../../utils/format';
 
 export interface VolumeActionOptions {
   onActionComplete?: () => void;
@@ -105,8 +107,21 @@ export class VolumeActionService {
 
   static async pruneVolumes(options: VolumeActionOptions = {}) {
     try {
-      const result = await invoke<string>('prune_volumes');
-      toast.success(result);
+      const result = await invoke<VolumePruneResult>('prune_volumes');
+      const count = result.volumes_deleted.length;
+
+      // Report exactly what the daemon said it removed. Anything derived on this
+      // side (a before/after volume count, for instance) races with the rest of
+      // the system and can credit the prune with volumes it never touched.
+      if (count === 0) {
+        toast.success('No unused anonymous volumes to remove');
+      } else {
+        toast.success(
+          `Removed ${count} ${this.getVolumeText(count)}, reclaimed ${formatBytes(
+            result.space_reclaimed
+          )}`
+        );
+      }
 
       setTimeout(() => {
         options.onActionComplete?.();

--- a/src/components/volumes/volume-actions.tsx
+++ b/src/components/volumes/volume-actions.tsx
@@ -78,10 +78,22 @@ export function VolumeActions({
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Confirm Prune Operation</DialogTitle>
-          <DialogDescription>
-            This will remove all unused volumes from your system. <br />
-            This action cannot be undone. Are you sure you want to continue?
+          <DialogTitle>Prune anonymous volumes?</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-3">
+              <p>
+                This removes <strong>anonymous</strong> volumes - the ones
+                Docker generated for a container - that no container is using
+                any more.
+              </p>
+              <p>
+                Named volumes are <strong>kept</strong>, even when nothing is
+                using them, because they are the ones you created deliberately
+                to outlive their containers. To remove a named volume, select it
+                in the table and use Delete.
+              </p>
+              <p>This cannot be undone.</p>
+            </div>
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -97,7 +109,7 @@ export function VolumeActions({
             onClick={handlePrune}
             disabled={isLoading === 'prune'}
           >
-            {isLoading === 'prune' ? 'Pruning...' : 'Prune Volumes'}
+            {isLoading === 'prune' ? 'Pruning...' : 'Prune Anonymous Volumes'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/volumes/volume-types.ts
+++ b/src/components/volumes/volume-types.ts
@@ -23,3 +23,9 @@ export interface Volume {
   options: Record<string, string>;
   usage_data?: UsageData;
 }
+
+// Volume prune result matching backend, taken verbatim from the daemon response
+export interface VolumePruneResult {
+  volumes_deleted: string[];
+  space_reclaimed: number;
+}


### PR DESCRIPTION
Closes #170

## Problem

`VolumesService::prune_volumes` called the daemon's prune endpoint - correct and conservative - and then ran a second, hand-rolled sweep that deleted every volume whose `ref_count` was zero.

That `ref_count` is not Docker's. `get_volumes` recomputes it by scanning `list_containers(all: true)` and matching `mount.name`, so any volume the daemon holds for a reason that does not surface as a container mount name is classified as unused. `unwrap_or(true)` made "no usage data" mean "safe to delete" too.

Docker restricts `volume prune` to *anonymous* volumes on purpose. The sweep removed **named** volumes as well - the ones users create precisely so they outlive their containers.

**Measured on a real developer machine** (37 volumes, 20 running containers): `docker volume prune` removes 0; the sweep would have deleted **29**, including `minikube`, `k3d-daedalus-images`, and every devcontainer and gcloud-cli volume.

## Verification

Both versions were run against a throwaway Docker-in-Docker daemon holding the same four volumes - one anonymous (orphaned by a removed container), `my-important-data` (created, never attached), `pg-data` (attached to a container since removed - the Postgres case), and `in-use` (held by a live container):

| volume | `docker volume prune` | before | after |
|---|---|---|---|
| `<anonymous>` | removed | removed | removed :white_check_mark: |
| `my-important-data` | kept | **deleted** :x: | kept :white_check_mark: |
| `pg-data` | kept | **deleted** :x: | kept :white_check_mark: |
| `in-use` | kept | kept | kept :white_check_mark: |

Driving the real service code, before:

```
before: ["in-use", "my-important-data", "pg-data", "3d61f9f5fa45...<anonymous>"]
after:  ["in-use"]
```

after:

```
before: ["48f5078d...<anonymous>", "in-use", "my-important-data", "pg-data"]
daemon reported deleted: ["48f5078d...<anonymous>"]
after: ["my-important-data", "pg-data", "in-use"]
```

A subsequent `docker volume prune` on the same daemon reports `Total reclaimed space: 0B`, confirming parity with the CLI. With 5 MiB written into an anonymous volume, the daemon reported `space_reclaimed: 5242880` - the exact figure now surfaced to the user, rather than an inferred one.

## Changes

- **`services/volumes.rs`** - the sweep is gone; the daemon's prune result is returned as-is. The daemon is the only party that can see every reason a volume is held (swarm cluster volumes, containers outside the current context), so its answer stands. Named volumes are removed only through an explicit selection, which already routes to `remove_volume` / `bulk_remove_volumes`.
- **`entities/volumes.rs`** - new `VolumePruneResult { volumes_deleted, space_reclaimed }` with a `From<VolumePruneResponse>` impl, mirroring the existing images `PruneResult`. Unit tests cover the mapping, including the daemon omitting both fields, which must read as zero rather than as missing data for the client to estimate.
- **`handlers/volumes.rs`** - drops the before/after count diff. It listed volumes twice around the prune and subtracted, which races with anything else touching the daemon and credits the prune for volumes it never touched. The response already carries the real numbers.
- **`volume-actions.tsx`** - the dialog said "This will remove all unused volumes from your system." "Unused" was doing all the damage: nothing told the user that a named volume with no running container counted. It now states that anonymous volumes go, named volumes stay, and how to remove a named volume deliberately.
- **`volume-actions-service.ts`** - the toast reports the daemon's count and reclaimed bytes ("Removed 3 volumes, reclaimed 1.2 GB"), and distinguishes "nothing to remove" from a successful removal.

## Scope note

This restores parity with `docker volume prune`. The `--all` semantic (which would also remove unattached named volumes) is deliberately **not** offered: it is the behaviour that caused the data loss, and putting it behind a checkbox would only relabel the hazard. Users who want a specific named volume gone can select it and press Delete.

Note that `ISSUE-036` reports the images prune going the other way - it hardcodes `dangling=false`, i.e. `prune -a` semantics. That is a separate change and is untouched here.

## Testing

- `cargo test` - 8 passed (2 new).
- `pre-commit run` on all changed files - eslint, TypeScript, lint, cargo fmt, cargo check, cargo test all pass.

The GUI click-through of Volumes -> Prune Unused was not run; the app is a native Tauri window and no native GUI automation is available in this environment. The daemon-level behaviour the bug consists of is verified directly against a real daemon instead, driving the actual service code rather than a reimplementation. The host machine's own 37 volumes were counted before and after and are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Volume pruning now reports the number of deleted anonymous volumes and reclaimed storage.
  - Added clearer feedback when no unused anonymous volumes are removed.
  - Updated the confirmation dialog and button label to clarify that named volumes are retained and must be deleted individually.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->