### PR TITLE
fix: return an error instead of panicking on non-macOS Colima commands

### DIFF
--- a/src-tauri/src/handlers/system/engine.rs
+++ b/src-tauri/src/handlers/system/engine.rs
@@ -1,6 +1,6 @@
 use crate::entities::EngineStatus;
 use crate::entities::{ColimaConfig, InstallationMethod};
-use crate::services::engine::{install_colima, start_colima_vm, stop_colima_vm};
+use crate::services::engine::{install_colima, start_colima_vm, stop_colima_vm, COLIMA_MANAGED};
 use crate::services::shell::{is_colima_available, is_homebrew_available};
 use crate::state::SharedEngineState;
 use tauri::State;
@@ -56,4 +56,17 @@ pub async fn stop_colima_vm_command(app: tauri::AppHandle) -> Result<(), String>
 pub async fn check_colima_availability(app: tauri::AppHandle) -> Result<bool, String> {
     info!("Checking Colima availability");
     is_colima_available(&app).await
+}
+
+/// Whether this build can install and run Colima at all.
+///
+/// `check_colima_availability` answers "is Colima installed on this machine";
+/// this answers the question that comes before it, so the frontend can leave
+/// the install / start / stop controls out entirely on a platform where they
+/// can never succeed.
+#[tauri::command]
+#[instrument(skip_all)]
+pub fn is_colima_supported() -> bool {
+    debug!("Colima supported on this platform: {}", COLIMA_MANAGED);
+    COLIMA_MANAGED
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ use crate::handlers::{
     get_theme,
     inspect_volume,
     install_colima_command,
+    is_colima_supported,
     // Containers
     list_containers,
     // Images
@@ -196,6 +197,7 @@ pub fn run() {
             start_engine_state_monitoring,
             check_homebrew_availability,
             check_colima_availability,
+            is_colima_supported,
             install_colima_command,
             start_colima_vm_command,
             stop_colima_vm_command,

--- a/src-tauri/src/services/engine/linux.rs
+++ b/src-tauri/src/services/engine/linux.rs
@@ -1,36 +1,29 @@
-#![allow(unused)]
-
 use crate::entities::{ColimaConfig, InstallationMethod};
+use crate::services::engine::colima_unmanaged;
 use crate::services::shell::get_docker_context_endpoints;
 use bollard::Docker;
 use tauri::AppHandle;
 use tracing::{debug, instrument, warn};
 
-#[instrument(skip_all, err)]
-pub async fn is_homebrew_available(_app: &AppHandle) -> Result<bool, String> {
-    // Homebrew is only available on macOS
-    Ok(false)
-}
+// Nookat does not manage a container engine on Linux: it connects to the
+// daemon the user already runs. These entry points exist so the shared
+// `#[tauri::command]` wrappers compile on every platform, and they report the
+// unsupported operation through the `Result` they already return. Returning an
+// error rather than panicking is the whole point - see `colima_unmanaged`.
 
 #[instrument(skip_all, err)]
 pub async fn install_colima(_app: &AppHandle, _method: InstallationMethod) -> Result<(), String> {
-    // Colima is only implemented on macOS for now, other platforms are not supported yet
-    todo!("Colima is only implemented on macOS for now, other platforms are not supported yet");
+    colima_unmanaged()
 }
 
 #[instrument(skip_all, err)]
 pub async fn start_colima_vm(_app: &AppHandle, _config: ColimaConfig) -> Result<(), String> {
-    todo!("Colima is only implemented on macOS for now, other platforms are not supported yet");
-}
-
-pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
-    todo!("Colima is only implemented on macOS for now, other platforms are not supported yet");
+    colima_unmanaged()
 }
 
 #[instrument(skip_all, err)]
-pub async fn is_colima_available(_app: &AppHandle) -> Result<bool, String> {
-    // Colima is only implemented on macOS for now, other platforms are not supported yet
-    Ok(false)
+pub async fn stop_colima_vm(_app: &AppHandle) -> Result<(), String> {
+    colima_unmanaged()
 }
 
 #[instrument(skip_all, err)]

--- a/src-tauri/src/services/engine/mod.rs
+++ b/src-tauri/src/services/engine/mod.rs
@@ -23,6 +23,29 @@ mod linux;
 #[cfg(target_os = "linux")]
 pub use linux::*;
 
+/// Whether this build manages a Colima VM itself.
+///
+/// Colima runs on macOS only. On every other platform Nookat attaches to a
+/// daemon that something else started, so the install / start / stop flows do
+/// not apply and must not be offered.
+pub const COLIMA_MANAGED: bool = cfg!(target_os = "macos");
+
+/// The answer the Colima install / start / stop entry points give on a platform
+/// where Nookat does not manage Colima.
+///
+/// This is an `Err` and never a panic. These functions are called directly from
+/// `#[tauri::command]` wrappers, and a panic inside a command aborts the task
+/// the command runs in: the `invoke()` promise on the frontend never settles,
+/// so the caller's `catch` never runs and the UI waits forever, while the
+/// Sentry panic hook files the non-implementation as a crash.
+#[cfg_attr(target_os = "macos", allow(dead_code))]
+pub fn colima_unmanaged<T>() -> Result<T, String> {
+    Err(format!(
+        "Colima is only supported on macOS. On {} Nookat connects to a Docker daemon that is already running.",
+        std::env::consts::OS
+    ))
+}
+
 #[instrument(skip_all, err)]
 async fn connect_to_docker_with_local_defaults() -> Result<Docker, String> {
     debug!("Trying to connect to Docker via local defaults");
@@ -100,7 +123,7 @@ pub fn should_stop_vm(status: &Result<bool, String>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::should_stop_vm;
+    use super::{colima_unmanaged, should_stop_vm, COLIMA_MANAGED};
 
     #[test]
     fn stops_when_the_vm_is_running() {
@@ -115,5 +138,60 @@ mod tests {
     #[test]
     fn attempts_the_stop_when_the_status_check_fails() {
         assert!(should_stop_vm(&Err("colima not found".to_string())));
+    }
+
+    #[test]
+    fn colima_is_managed_on_macos_only() {
+        assert_eq!(COLIMA_MANAGED, cfg!(target_os = "macos"));
+    }
+
+    #[test]
+    fn the_unmanaged_answer_is_an_error_and_names_both_platforms() {
+        let message = colima_unmanaged::<()>().expect_err("must not be Ok");
+        assert!(message.contains("macOS"), "{message}");
+        assert!(message.contains(std::env::consts::OS), "{message}");
+    }
+
+    /// The install / start / stop entry points are called straight from
+    /// `#[tauri::command]` wrappers. A panic inside a command aborts the task
+    /// it runs in, so the `invoke()` promise never settles: the frontend's
+    /// `catch` never runs, the UI waits on a reply that will not arrive, and
+    /// the Sentry panic hook reports the missing implementation as a crash.
+    /// Every one of those signatures returns `Result`, so an unsupported
+    /// operation is an `Err`. Guard the whole backend against the pattern
+    /// coming back.
+    #[test]
+    fn no_panicking_placeholders_in_services_or_handlers() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+
+        let mut stack = vec![root.join("services"), root.join("handlers")];
+        while let Some(path) = stack.pop() {
+            let entries = std::fs::read_dir(&path).expect("readable source directory");
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().is_none_or(|ext| ext != "rs") {
+                    continue;
+                }
+                let source = std::fs::read_to_string(&path).expect("readable source file");
+                // Split so this scanner does not match its own source.
+                let placeholders = [concat!("todo", "!("), concat!("unimplemented", "!(")];
+                for (index, line) in source.lines().enumerate() {
+                    if placeholders.iter().any(|p| line.contains(p)) {
+                        offenders.push(format!("{}:{}", path.display(), index + 1));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "panicking placeholder reachable from a Tauri command: {}",
+            offenders.join(", ")
+        );
     }
 }

--- a/src-tauri/src/services/engine/windows.rs
+++ b/src-tauri/src/services/engine/windows.rs
@@ -1,34 +1,29 @@
 use crate::entities::{ColimaConfig, InstallationMethod};
+use crate::services::engine::colima_unmanaged;
 use crate::services::shell::get_docker_context_endpoints;
 use bollard::Docker;
 use tauri::AppHandle;
 use tracing::{debug, instrument, warn};
 
-#[instrument(skip_all, err)]
-pub async fn is_homebrew_available(_app: &AppHandle) -> Result<bool, String> {
-    // Homebrew is only available on macOS
-    Ok(false)
-}
+// Nookat does not manage a container engine on Windows: it connects to the
+// daemon the user already runs. These entry points exist so the shared
+// `#[tauri::command]` wrappers compile on every platform, and they report the
+// unsupported operation through the `Result` they already return. Returning an
+// error rather than panicking is the whole point - see `colima_unmanaged`.
 
 #[instrument(skip_all, err)]
 pub async fn install_colima(_app: &AppHandle, _method: InstallationMethod) -> Result<(), String> {
-    // Colima is only implemented on macOS for now, other platforms are not supported yet
-    todo!("Colima is only implemented on macOS for now, other platforms are not supported yet");
+    colima_unmanaged()
 }
 
 #[instrument(skip_all, err)]
 pub async fn start_colima_vm(_app: &AppHandle, _config: ColimaConfig) -> Result<(), String> {
-    todo!("Colima is only implemented on macOS for now, other platforms are not supported yet");
-}
-
-pub async fn stop_colima_vm(app_handle: &AppHandle) -> Result<(), String> {
-    todo!("Colima is only implemented on macOS for now, other platforms are not supported yet");
+    colima_unmanaged()
 }
 
 #[instrument(skip_all, err)]
-pub async fn is_colima_available(_app: &AppHandle) -> Result<bool, String> {
-    // Colima is only implemented on macOS for now, other platforms are not supported yet
-    Ok(false)
+pub async fn stop_colima_vm(_app: &AppHandle) -> Result<(), String> {
+    colima_unmanaged()
 }
 
 #[instrument(skip_all, err)]

--- a/src/components/settings/engine-settings/components/engine-configuration.tsx
+++ b/src/components/settings/engine-settings/components/engine-configuration.tsx
@@ -17,6 +17,7 @@ import {
   Terminal,
   Info,
   AlertTriangle,
+  RefreshCw,
 } from 'lucide-react';
 import {
   ColimaConfig,
@@ -38,6 +39,8 @@ import { useState } from 'react';
 interface EngineConfigurationProps {
   dockerInfo: DockerInfo | null;
   colimaSupported: boolean | null;
+  colimaSupportError: string | null;
+  onRetrySupportCheck: () => void;
   colimaAvailable: boolean | null;
   config: ColimaConfig;
   onConfigChange: (config: ColimaConfig) => void;
@@ -61,6 +64,8 @@ interface EngineConfigurationProps {
 export function EngineConfiguration({
   dockerInfo,
   colimaSupported,
+  colimaSupportError,
+  onRetrySupportCheck,
   colimaAvailable,
   config,
   onConfigChange,
@@ -95,6 +100,27 @@ export function EngineConfiguration({
         title="Engine management is available on macOS only"
         message="Nookat installs and runs the Colima engine on macOS. On this platform it connects to the Docker daemon already running on your machine - start, stop and configure that daemon with the tool you installed it with."
       />
+    );
+  }
+
+  // The platform probe failed, so whether Colima applies here is unknown.
+  // Guessing either way is worse than saying so: guessing "supported" offers
+  // controls that may not work, guessing "unsupported" hides the only way to
+  // start an engine on macOS.
+  if (colimaSupportError) {
+    return (
+      <div className="space-y-3">
+        <InfoBanner
+          icon={AlertTriangle}
+          title="Could not determine engine support for this platform"
+          message={colimaSupportError}
+          variant="error"
+        />
+        <Button onClick={onRetrySupportCheck} variant="outline" size="sm">
+          <RefreshCw className="h-4 w-4 mr-2" />
+          Retry
+        </Button>
+      </div>
     );
   }
 

--- a/src/components/settings/engine-settings/components/engine-configuration.tsx
+++ b/src/components/settings/engine-settings/components/engine-configuration.tsx
@@ -30,12 +30,14 @@ import { ResourceInput } from './resource-input';
 import { InstallationProgress } from './installation-progress';
 import { MethodCard, InfoBanner } from './index';
 import { DockerInfo } from '../../../../types/docker-info';
+import { LoadingSpinner } from '../../../ui/loading-spinner';
 import { ConfirmDialog } from '../../../common/ConfirmDialog';
 import { Dialog, DialogTrigger } from '../../../ui/dialog';
 import { useState } from 'react';
 
 interface EngineConfigurationProps {
   dockerInfo: DockerInfo | null;
+  colimaSupported: boolean | null;
   colimaAvailable: boolean | null;
   config: ColimaConfig;
   onConfigChange: (config: ColimaConfig) => void;
@@ -58,6 +60,7 @@ interface EngineConfigurationProps {
 
 export function EngineConfiguration({
   dockerInfo,
+  colimaSupported,
   colimaAvailable,
   config,
   onConfigChange,
@@ -80,6 +83,28 @@ export function EngineConfiguration({
   const showStopProgress = stopStep !== 'idle';
   const isStopping = stopStep === 'stopping-vm' || stopStep === 'stopping';
   const [isStopDialogOpen, setIsStopDialogOpen] = useState(false);
+
+  // Colima only runs on macOS. Everywhere else Nookat attaches to a daemon
+  // something else started, so there is nothing here to install, start or
+  // stop - and offering those controls would offer actions the backend can
+  // only refuse.
+  if (colimaSupported === false) {
+    return (
+      <InfoBanner
+        icon={Info}
+        title="Engine management is available on macOS only"
+        message="Nookat installs and runs the Colima engine on macOS. On this platform it connects to the Docker daemon already running on your machine - start, stop and configure that daemon with the tool you installed it with."
+      />
+    );
+  }
+
+  // Nothing is known about the engine yet. Rendering the configuration form
+  // now only makes it flash on screen before the install card replaces it.
+  if (colimaSupported === null || colimaAvailable === null) {
+    return (
+      <LoadingSpinner message="Checking engine setup..." className="py-8" />
+    );
+  }
 
   // Show installation section if Colima is not available
   if (colimaAvailable === false) {

--- a/src/components/settings/engine-settings/engine-settings.tsx
+++ b/src/components/settings/engine-settings/engine-settings.tsx
@@ -58,6 +58,8 @@ export function EngineSettings() {
         <EngineConfiguration
           dockerInfo={state.dockerInfo}
           colimaSupported={state.colimaSupported}
+          colimaSupportError={state.colimaSupportError}
+          onRetrySupportCheck={actions.checkColimaSupport}
           colimaAvailable={state.colimaAvailable}
           config={state.config}
           onConfigChange={actions.setConfig}

--- a/src/components/settings/engine-settings/engine-settings.tsx
+++ b/src/components/settings/engine-settings/engine-settings.tsx
@@ -57,6 +57,7 @@ export function EngineSettings() {
       >
         <EngineConfiguration
           dockerInfo={state.dockerInfo}
+          colimaSupported={state.colimaSupported}
           colimaAvailable={state.colimaAvailable}
           config={state.config}
           onConfigChange={actions.setConfig}

--- a/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
+++ b/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
@@ -12,6 +12,10 @@ import {
 } from '../types';
 
 export interface EngineSettingsState {
+  // Platform support: whether this build manages Colima at all. Null until the
+  // backend answers.
+  colimaSupported: boolean | null;
+
   // Installation state
   method: InstallationMethod;
   installationStep: InstallationStep;
@@ -46,6 +50,9 @@ export function useEngineSettingsState(): [
   EngineSettingsState,
   EngineSettingsActions,
 ] {
+  // Platform support
+  const [colimaSupported, setColimaSupported] = useState<boolean | null>(null);
+
   // Installation state
   const [method, setMethod] = useState<InstallationMethod>('homebrew');
   const [installationStep, setInstallationStep] =
@@ -81,6 +88,17 @@ export function useEngineSettingsState(): [
   // UI state
   const [showEngineConfig, setShowEngineConfig] = useState(true);
 
+  // Whether this build can manage Colima at all. Platform-constant, so it is
+  // asked once and never re-probed.
+  useEffect(() => {
+    invoke<boolean>('is_colima_supported')
+      .then(setColimaSupported)
+      .catch(error => {
+        console.error('Error checking Colima platform support:', error);
+        setColimaSupported(false);
+      });
+  }, []);
+
   // Check availability on mount
   useEffect(() => {
     const checkAvailability = async () => {
@@ -98,10 +116,6 @@ export function useEngineSettingsState(): [
         if (!isHomebrewAvailable && method === 'homebrew') {
           setMethod('binary');
         }
-
-        if (isColimaAvailable) {
-          fetchDockerInfo();
-        }
       } catch (error) {
         console.error('Error checking availability:', error);
         setHomebrewAvailable(false);
@@ -110,6 +124,12 @@ export function useEngineSettingsState(): [
           setMethod('binary');
         }
       }
+
+      // Engine info comes from whichever daemon is reachable, which on Linux
+      // and Windows - and on macOS behind Docker Desktop - is never Colima.
+      // Gating this on Colima left the Engine Status card empty for everyone
+      // else.
+      fetchDockerInfo();
     };
 
     checkAvailability();
@@ -347,6 +367,7 @@ export function useEngineSettingsState(): [
   };
 
   const state: EngineSettingsState = {
+    colimaSupported,
     method,
     installationStep,
     stopStep,

--- a/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
+++ b/src/components/settings/engine-settings/hooks/use-engine-settings-state.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { DockerInfo } from '../../../../types/docker-info';
@@ -12,9 +12,10 @@ import {
 } from '../types';
 
 export interface EngineSettingsState {
-  // Platform support: whether this build manages Colima at all. Null until the
-  // backend answers.
+  // Platform support: whether this build manages Colima at all. Null while the
+  // answer is still unknown, which includes a failed probe.
   colimaSupported: boolean | null;
+  colimaSupportError: string | null;
 
   // Installation state
   method: InstallationMethod;
@@ -44,6 +45,7 @@ export interface EngineSettingsActions {
   handleRetry: () => void;
   fetchDockerInfo: () => Promise<void>;
   handleStopEngine: () => Promise<void>;
+  checkColimaSupport: () => Promise<void>;
 }
 
 export function useEngineSettingsState(): [
@@ -52,6 +54,9 @@ export function useEngineSettingsState(): [
 ] {
   // Platform support
   const [colimaSupported, setColimaSupported] = useState<boolean | null>(null);
+  const [colimaSupportError, setColimaSupportError] = useState<string | null>(
+    null
+  );
 
   // Installation state
   const [method, setMethod] = useState<InstallationMethod>('homebrew');
@@ -88,16 +93,29 @@ export function useEngineSettingsState(): [
   // UI state
   const [showEngineConfig, setShowEngineConfig] = useState(true);
 
-  // Whether this build can manage Colima at all. Platform-constant, so it is
-  // asked once and never re-probed.
-  useEffect(() => {
-    invoke<boolean>('is_colima_supported')
-      .then(setColimaSupported)
-      .catch(error => {
-        console.error('Error checking Colima platform support:', error);
-        setColimaSupported(false);
-      });
+  // Whether this build can manage Colima at all. The answer is
+  // platform-constant, so this gets its own mount-time effect rather than
+  // riding along with the availability checks below, which refire. Retry is
+  // the only thing that asks again.
+  const checkColimaSupport = useCallback(async () => {
+    setColimaSupportError(null);
+    try {
+      setColimaSupported(await invoke<boolean>('is_colima_supported'));
+    } catch (err) {
+      // A failed probe is not an answer. Reading it as "unsupported" would
+      // hide the install and start controls on macOS - where they are the
+      // only way to get an engine running - and tell the user Colima works
+      // on macOS only while they are sitting on macOS. Stay unknown and let
+      // them retry.
+      console.error('Error checking Colima platform support:', err);
+      setColimaSupported(null);
+      setColimaSupportError(err instanceof Error ? err.message : String(err));
+    }
   }, []);
+
+  useEffect(() => {
+    checkColimaSupport();
+  }, [checkColimaSupport]);
 
   // Check availability on mount
   useEffect(() => {
@@ -368,6 +386,7 @@ export function useEngineSettingsState(): [
 
   const state: EngineSettingsState = {
     colimaSupported,
+    colimaSupportError,
     method,
     installationStep,
     stopStep,
@@ -393,6 +412,7 @@ export function useEngineSettingsState(): [
     handleRetry,
     fetchDockerInfo,
     handleStopEngine,
+    checkColimaSupport,
   };
 
   return [state, actions];


### PR DESCRIPTION
Closes #172

## Problem

`install_colima`, `start_colima_vm` and `stop_colima_vm` were `todo!()` on Linux and Windows, while the Tauri commands that call them were registered on every platform in `generate_handler![]`. All three already return `Result<(), String>`, so the panic bought nothing.

It cost two things, and the second is the one that matters.

## Verification

Driven through the real Tauri IPC path - `tauri::test::mock_builder`, a command whose body is the current `todo!()`, invoked via `on_message` exactly as the webview does:

```
--- current code (todo!) ---
>>> PANIC HOOK FIRED (this is what Sentry captures): panicked at repro:16:5:
not yet implemented: Colima is only implemented on macOS for now, other platforms are not supported yet
  result: Err("NO RESPONSE - the invoke() promise never settles")
  panic hook fired: true
--- returning Err instead ---
  result: Ok("Err(InvokeError(String(\"Colima is only supported on macOS.\")))")
  panic hook fired: false
```

1. **The panic is filed as a crash.** The Sentry client is built with the `panic` feature, so its hook captures a deliberate non-implementation and reports it as a production crash.

2. **The `invoke()` promise never settles.** The panic aborts the task the command runs in, so no response is ever sent. It neither resolves nor rejects: the `catch` in `handleInstall` never runs, `setInstallationStep('error')` never fires, `installationStep` stays `'installing'`, and `InstallationProgress` renders its Retry button only under an error state. The Engine Settings page is left on a spinner at 0% with no way out but restarting the app.

Returning `Err` settles the promise with the message, which is what every other failing command in the app already does.

### Reachability, honestly

Through the shipped UI these commands were hard to reach - by accident, not by design. Rendering the pre-fix frontend against a mocked bridge answering as Linux does (`is_colima_supported: false`, `check_homebrew_availability: false`, `check_colima_availability: false`, a live daemon behind `get_docker_info`) confirms it:

- The Engine Status card reads **"No engine information available"** even though the daemon is up, because `fetchDockerInfo` was gated on Colima being available.
- The install card offers **"Install Colima"** with the advice *"Install Homebrew first or use Binary installation method"* - advice that cannot be followed, since the Binary card is hard-disabled (ISSUE-026).
- The Install button is disabled, but only because `homebrewAvailable === false` flipped `method` to `'binary'`.
- "Stop Engine" never renders, but only because `dockerInfo` stays null.

So the crash was one frontend change away rather than one click away. Concretely: ungating `fetchDockerInfo` - the obvious fix for that empty status card, and part of this PR - makes `isEngineRunning` true wherever a daemon runs, which renders "Stop Engine", which is a single click into `stop_colima_vm_command` and the hang. Both halves belong in the same change.

### After

Same mocked bridge, answering as Linux, with this branch:

| | before | after |
|---|---|---|
| Engine Status card | "No engine information available" | Container statistics, engine version, storage driver, capacity - the running daemon |
| Engine Configuration | "Install Colima" + a disabled button | "Engine management is available on macOS only", with what Nookat does instead |
| `stop_colima_vm_command` | panic, promise hangs, crash report | `Err("Colima is only supported on macOS. On linux Nookat connects to a Docker daemon that is already running.")` |

Checked in light and dark themes. The macOS path is unchanged: the install card still renders with Homebrew selected and the Install button live.

## Changes

- **`services/engine/mod.rs`** - `colima_unmanaged()` is the single answer the three entry points give where Nookat does not manage Colima, an `Err` naming the platform. `COLIMA_MANAGED` records whether this build manages it at all. Defining both once means Linux and Windows cannot drift apart, and a fourth platform inherits the behaviour.
- **`services/engine/{linux,windows}.rs`** - the three `todo!()`s become `colima_unmanaged()`. `stop_colima_vm` gains the `#[instrument]` attribute the rest of the codebase uses and stops taking an `app_handle` it never reads.
- **`services/engine/linux.rs`** - drops `#![allow(unused)]`, which was suppressing exactly the dead-code and unused-variable signals that would have flagged this module as unfinished. With it go the dead `is_homebrew_available` / `is_colima_available` duplicates of the real `services/shell` versions. `services/engine/macos.rs` defines neither, so those two made `services::engine::is_colima_available` exist on two platforms out of three; nothing called them.
- **`handlers/system/engine.rs`, `lib.rs`** - new `is_colima_supported` command. `check_colima_availability` answers "is Colima installed on this machine"; this answers the question before it, so the frontend can leave the controls out where they can never succeed. One `cfg!` decides both the backend's answer and the UI's shape.
- **`engine-configuration.tsx`** - renders an explanatory banner instead of install / start / stop controls when Colima is unsupported, and a loading state while the checks are in flight rather than showing the VM Resources form and replacing it a moment later.
- **`use-engine-settings-state.ts`** - probes `is_colima_supported` once (its own `[]` effect - the value is platform-constant, and the existing availability effect refires, see ISSUE-020), and fetches Docker info regardless of Colima.

## Regression guard

`no_panicking_placeholders_in_services_or_handlers` walks `services/` and `handlers/` for `todo!()` and `unimplemented!()`. Reintroducing one fails the test with the file and line:

```
panicking placeholder reachable from a Tauri command: src/services/engine/linux.rs:16
```

Clippy is not part of the pipeline, so `#![deny(clippy::todo)]` would not be enforced; a test is. It also catches placeholders in files the current platform does not compile, which is the whole failure mode here - and CI runs `cargo test` on `ubuntu-22.04`, where these files are compiled for real.

## Scope note

Two adjacent defects are named above but left alone: the Binary installation dead end (ISSUE-026) and the availability effect refiring on `method` (ISSUE-020). Ungating `fetchDockerInfo` is in scope because hiding the Colima controls without it would leave non-macOS users an Engine page with no information at all.

## Review fix

The first commit caught the `is_colima_supported` rejection and set `colimaSupported` to `false`, which is the one wrong answer to give. On macOS that would hide the install and start controls - the only way to get an engine running - and tell the user Colima is supported on macOS only while they are sitting on macOS, with no way back short of restarting the app. A failed probe is not an answer: `colimaSupported` now stays `null`, the error is recorded, and the section renders it with a Retry that re-runs the check. `false` is reserved for a backend that actually answered `false`.

Rendered against a bridge whose `is_colima_supported` rejects: an error banner carrying the message, a working Retry, and the Engine Status card still populated.

## Testing

- `cargo test` - 11 passed (3 new).
- `pre-commit run --all-files` - eslint, TypeScript, lint, cargo fmt, cargo check, cargo test all pass.
- `cargo test` on a real Linux toolchain (Debian bookworm container with the Tauri system deps) - 11 passed. A macOS `cargo check` never compiles `services/engine/linux.rs`, so this is the run that proves the rewritten Linux module builds and that `colima_unmanaged` reports `linux` there. CI's `ubuntu-22.04` Platform Build passed too.

The GUI click-through in the packaged app was not run - it is a native Tauri window and no native GUI automation is available in this environment. The frontend was instead driven in a browser against a mocked Tauri bridge, and the backend behaviour was driven through Tauri's own IPC machinery, as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkPrfYiTBqa8nwvZeRy7iA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform support detection for Colima.
  * Added an error banner and retry option when support detection fails.
  * Colima operations on unsupported platforms now return a clear error instead of failing unexpectedly.

* **Bug Fixes**
  * Improved handling of unsupported Colima operations on Linux and Windows.
  * Added clearer feedback when the platform cannot manage Colima.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->