### PR TITLE
chore: build macOS release without Apple signing or notarization

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -8,8 +8,9 @@ name: Build macOS
 #
 # To restore proper signing + notarization once an Apple Developer Program
 # membership is available, re-add the APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD
-# / KEYCHAIN_PASSWORD / APPLE_ID / APPLE_ID_PASSWORD / APPLE_TEAM_ID secrets, the
-# keychain import step, and drop the ad-hoc APPLE_SIGNING_IDENTITY below.
+# / KEYCHAIN_PASSWORD / APPLE_ID / APPLE_ID_PASSWORD / APPLE_TEAM_ID secrets and
+# the keychain import step, and drop the ad-hoc APPLE_SIGNING_IDENTITY from both
+# tauri-action steps below.
 
 on:
   workflow_call:
@@ -70,10 +71,58 @@ jobs:
             exit 1
           fi
 
-      - name: Build and Publish
+      # The build and the release upload are deliberately two separate
+      # tauri-action invocations. tauri-action creates the release and uploads
+      # assets inside the same step that builds, so a single invocation would
+      # publish the DMG before anything had a chance to check it. Splitting them
+      # lets the signature check gate the upload: a bundle that fails
+      # verification never reaches the draft release. tauri-action skips all
+      # uploads when neither tagName nor releaseId is set.
+      #
+      # tauri-action always builds, so the publish step re-runs `tauri build`.
+      # Cargo is incremental within the job, so nothing is recompiled and the
+      # cost is one extra bundling pass. There is no supported way to hand
+      # tauri-action a set of already-built artifacts, and generating latest.json
+      # by hand instead would duplicate logic the Linux and Windows jobs share.
+      - name: Build
+        id: build
         uses: tauri-apps/tauri-action@v0
         env:
           # Ad-hoc signature. No Apple Developer ID, no notarization.
+          APPLE_SIGNING_IDENTITY: '-'
+          VITE_APTABASE_APP_KEY: ${{ secrets.VITE_APTABASE_APP_KEY }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          args: --target universal-apple-darwin
+
+      - name: Verify ad-hoc signature
+        env:
+          ARTIFACT_PATHS: ${{ steps.build.outputs.artifactPaths }}
+        run: |
+          set -euo pipefail
+
+          APPS=$(printf '%s' "$ARTIFACT_PATHS" | jq -r '.[] | select(endswith(".app"))')
+          if [ -z "$APPS" ]; then
+            echo "No .app bundle found in the build artifacts:"
+            printf '%s\n' "$ARTIFACT_PATHS"
+            exit 1
+          fi
+
+          while IFS= read -r app; do
+            echo "Verifying $app"
+            codesign --verify --deep --strict --verbose=2 "$app"
+            codesign --display --verbose=2 "$app"
+          done <<< "$APPS"
+
+          echo "Ad-hoc signature verified. The app is intentionally not notarized."
+
+      - name: Publish draft release
+        uses: tauri-apps/tauri-action@v0
+        env:
           APPLE_SIGNING_IDENTITY: '-'
           VITE_APTABASE_APP_KEY: ${{ secrets.VITE_APTABASE_APP_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
@@ -88,17 +137,6 @@ jobs:
           releaseDraft: true
           updaterJsonKeepUniversal: true
           args: --target universal-apple-darwin
-
-      - name: Verify ad-hoc signature
-        run: |
-          APP="src-tauri/target/universal-apple-darwin/release/bundle/macos/Nookat.app"
-          if [ ! -d "$APP" ]; then
-            echo "Expected app bundle not found at $APP"
-            exit 1
-          fi
-          codesign --verify --deep --strict --verbose=2 "$APP"
-          codesign --display --verbose=2 "$APP"
-          echo "Ad-hoc signature verified. The app is intentionally not notarized."
 
       - name: Build Summary
         run: |

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -144,4 +144,4 @@ jobs:
           echo "Version: ${{ inputs.version }}"
           echo "Version Tag: ${{ inputs.version-tag }}"
           echo "Target: universal-apple-darwin (aarch64 + x86_64)"
-          echo "Signing: ad-hoc (unsigned, not notarized) - users must allow the app in Privacy & Security"
+          echo "Signing: ad-hoc, no Developer ID, not notarized - users must allow the app in Privacy & Security"

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -1,5 +1,16 @@
 name: Build macOS
 
+# NOTE: This build is NOT signed with an Apple Developer ID and NOT notarized.
+# The bundle is ad-hoc signed instead (APPLE_SIGNING_IDENTITY: '-'), which is the
+# minimum macOS requires to launch a universal binary on Apple Silicon. Users will
+# still see a Gatekeeper "unidentified developer" warning on first launch and have
+# to allow the app explicitly (see the macOS section in README.md).
+#
+# To restore proper signing + notarization once an Apple Developer Program
+# membership is available, re-add the APPLE_CERTIFICATE / APPLE_CERTIFICATE_PASSWORD
+# / KEYCHAIN_PASSWORD / APPLE_ID / APPLE_ID_PASSWORD / APPLE_TEAM_ID secrets, the
+# keychain import step, and drop the ad-hoc APPLE_SIGNING_IDENTITY below.
+
 on:
   workflow_call:
     inputs:
@@ -10,18 +21,6 @@ on:
         required: true
         type: string
     secrets:
-      APPLE_CERTIFICATE:
-        required: true
-      APPLE_CERTIFICATE_PASSWORD:
-        required: true
-      KEYCHAIN_PASSWORD:
-        required: true
-      APPLE_ID:
-        required: true
-      APPLE_ID_PASSWORD:
-        required: true
-      APPLE_TEAM_ID:
-        required: true
       TAURI_SIGNING_PUBLIC_KEY:
         required: true
       TAURI_SIGNING_PRIVATE_KEY:
@@ -59,27 +58,6 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
-      - name: Import Apple Developer Certificate
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          security set-keychain-settings -t 3600 -u build.keychain
-          security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
-          security find-identity -v -p codesigning build.keychain
-
-      - name: Verify certificate
-        run: |
-          CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")
-          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
-          echo "Certificate imported successfully."
-
       - name: Set public key for updater
         env:
           TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
@@ -95,12 +73,8 @@ jobs:
       - name: Build and Publish
         uses: tauri-apps/tauri-action@v0
         env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          # Ad-hoc signature. No Apple Developer ID, no notarization.
+          APPLE_SIGNING_IDENTITY: '-'
           VITE_APTABASE_APP_KEY: ${{ secrets.VITE_APTABASE_APP_KEY }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -115,9 +89,21 @@ jobs:
           updaterJsonKeepUniversal: true
           args: --target universal-apple-darwin
 
+      - name: Verify ad-hoc signature
+        run: |
+          APP="src-tauri/target/universal-apple-darwin/release/bundle/macos/Nookat.app"
+          if [ ! -d "$APP" ]; then
+            echo "Expected app bundle not found at $APP"
+            exit 1
+          fi
+          codesign --verify --deep --strict --verbose=2 "$APP"
+          codesign --display --verbose=2 "$APP"
+          echo "Ad-hoc signature verified. The app is intentionally not notarized."
+
       - name: Build Summary
         run: |
           echo "✅ macOS build completed successfully!"
           echo "Version: ${{ inputs.version }}"
           echo "Version Tag: ${{ inputs.version-tag }}"
           echo "Target: universal-apple-darwin (aarch64 + x86_64)"
+          echo "Signing: ad-hoc (unsigned, not notarized) - users must allow the app in Privacy & Security"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "Preparing release ${{ steps.get-version.outputs.version-tag }}..."
           echo "Release coordination started at $(date)"
 
-  # macOS build job (unsigned / ad-hoc signed - see build-macos.yaml)
+  # macOS build job (ad-hoc signed, not notarized - see build-macos.yaml)
   build-macos:
     needs: release-coordinator
     uses: ./.github/workflows/build-macos.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "Preparing release ${{ steps.get-version.outputs.version-tag }}..."
           echo "Release coordination started at $(date)"
 
-  # macOS build job
+  # macOS build job (unsigned / ad-hoc signed - see build-macos.yaml)
   build-macos:
     needs: release-coordinator
     uses: ./.github/workflows/build-macos.yaml
@@ -50,12 +50,6 @@ jobs:
       version: ${{ needs.release-coordinator.outputs.version }}
       version-tag: ${{ needs.release-coordinator.outputs.version-tag }}
     secrets:
-      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
       TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
       TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ You can download the latest release from [GitHub Releases](https://github.com/no
 ### macOS: first launch
 
 The macOS builds are not signed with an Apple Developer ID, so Gatekeeper will refuse to open the app on the first launch with a message like "Nookat cannot be opened because Apple cannot check it for malicious software".
-This is expected, and the app is safe - it is built in public from this repository by the [release workflow](.github/workflows/build-macos.yaml).
+The warning means macOS cannot tell who published the app, which is expected here: releases are built by the public [release workflow](.github/workflows/build-macos.yaml) in this repository, and we do not currently hold the Apple Developer Program membership that signing and notarization require.
 
 To allow it, open the DMG, drag Nookat to Applications, and then either:
 
 - Right-click (or Control-click) Nookat in Applications and choose **Open**, then confirm **Open** in the dialog, or
-- Open **System Settings -> Privacy & Security**, scroll to the message about Nookat being blocked, and click **Open Anyway**.
+- Open Nookat normally and let macOS block it, then go to **System Settings -> Privacy & Security**, scroll to the message about Nookat being blocked, and click **Open Anyway**. The message and the button only appear after a blocked launch attempt.
 
 You only need to do this once.
-Both options keep macOS in charge of checking the app, so use them rather than stripping the quarantine attribute by hand - that would skip the check for every file in the bundle, including on a download that is not actually the one we published.
+Prefer either of these over stripping the quarantine attribute by hand: they scope the exception to this one app and leave macOS to keep checking everything else you download.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ _Container management interface_
 
 You can download the latest release from [GitHub Releases](https://github.com/nookat-io/nookat/releases)
 
+### macOS: first launch
+
+The macOS builds are not signed with an Apple Developer ID, so Gatekeeper will refuse to open the app on the first launch with a message like "Nookat cannot be opened because Apple cannot check it for malicious software".
+This is expected, and the app is safe - it is built in public from this repository by the [release workflow](.github/workflows/build-macos.yaml).
+
+To allow it, open the DMG, drag Nookat to Applications, and then either:
+
+- Right-click (or Control-click) Nookat in Applications and choose **Open**, then confirm **Open** in the dialog, or
+- Open **System Settings -> Privacy & Security**, scroll to the message about Nookat being blocked, and click **Open Anyway**.
+
+You only need to do this once.
+If macOS still refuses to launch it, clear the download quarantine flag manually:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Nookat.app
+```
+
 ## Development Setup
 
 ### Prerequisites
@@ -111,7 +128,7 @@ Nookat is built with a modern, cross-platform architecture:
 
 - **Frontend**: React with TypeScript and Tailwind CSS
 - **Backend**: Rust with Tauri
-- **Container Engine**: Colima an Lima as a container runtime
+- **Container Engine**: Colima and Lima as a container runtime
 - **Docker API**: bollard-rs for Docker daemon communication
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -85,11 +85,7 @@ To allow it, open the DMG, drag Nookat to Applications, and then either:
 - Open **System Settings -> Privacy & Security**, scroll to the message about Nookat being blocked, and click **Open Anyway**.
 
 You only need to do this once.
-If macOS still refuses to launch it, clear the download quarantine flag manually:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/Nookat.app
-```
+Both options keep macOS in charge of checking the app, so use them rather than stripping the quarantine attribute by hand - that would skip the check for every file in the bundle, including on a download that is not actually the one we published.
 
 ## Development Setup
 


### PR DESCRIPTION
## Problem

The v0.1.8 release pipeline succeeds on Linux and Windows but fails on macOS: the Apple Developer Program membership has expired, so the certificate import and notarization steps in `build-macos.yaml` can no longer run.

## Approach

Build and ship the macOS DMG unsigned rather than renewing the membership for now.

The bundle is **ad-hoc signed** (`APPLE_SIGNING_IDENTITY: '-'`) rather than left completely unsigned. This matters: a fully unsigned universal binary on Apple Silicon fails to launch with *"Nookat is damaged and can't be opened"*, which reads to users as a corrupt download rather than a permissions prompt. With an ad-hoc signature they get the ordinary *"unidentified developer"* warning and can allow the app once from **Privacy & Security**.

## Changes

- **`.github/workflows/build-macos.yaml`**
  - Removed the "Import Apple Developer Certificate" and "Verify certificate" steps.
  - Removed the six Apple secrets from the `workflow_call` contract and from the build step env. Notarization is skipped as a result: `tauri-bundler` only notarizes when `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` are present.
  - Set `APPLE_SIGNING_IDENTITY: '-'` for the ad-hoc signature.
  - Added a `codesign --verify --deep --strict` step after the build so a silently unsigned bundle fails CI instead of shipping.
  - Header comment documents exactly what to restore when a membership is available again.
- **`.github/workflows/release.yaml`** - dropped the same six secrets from the `build-macos` call. A reusable workflow rejects secrets its contract does not declare, so this had to move in lockstep.
- **`README.md`** - added a "macOS: first launch" section covering right-click -> Open, Privacy & Security -> Open Anyway, and `xattr -dr com.apple.quarantine` as a fallback. Also fixes a pre-existing typo ("Colima an Lima").

Updater signing is untouched. `TAURI_SIGNING_*` is Tauri's own minisign key and has nothing to do with Apple code signing.

## Things to watch

1. **Existing 0.1.7 users auto-updating.** They currently run a notarized app and the updater will replace it in place with an ad-hoc signed one. The update itself works, since Tauri verifies its own signature rather than Apple's, but the app's code identity changes and anything macOS keyed to the old signature resets. Nookat does not request accessibility or screen-recording permissions, so no user-visible fallout is expected - worth confirming on the first update after this release.
2. **`bundle_dmg.sh` flakiness.** Tauri has a long-standing intermittent DMG bundling failure on CI (tauri-apps/tauri#3055, resurfaced as tauri-apps/tauri#13804) that is unrelated to signing. If the macOS job fails at the DMG stage, re-run it before investigating.

The `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_ID`, `APPLE_ID_PASSWORD`, and `APPLE_TEAM_ID` repository secrets are now unreferenced. They can stay for when the membership is renewed.

## Testing

`pre-commit run` passes on all changed files; both workflow files parse as valid YAML. The macOS job itself is only exercised by a push to `release`, so the real verification is the next release run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added macOS first-launch guidance for approving unsigned or ad-hoc signed apps through Gatekeeper.
  * Clarified that approval is needed only once and is preferred over manually removing quarantine restrictions.
  * Corrected a typo in the architecture documentation.

* **Build and Release**
  * macOS builds now use ad-hoc signing instead of Developer ID signing and notarization.
  * Release checks verify the app signature and identify its signing status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->